### PR TITLE
chore: remove unit-test step #5

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -12,26 +12,6 @@ nox.options.sessions = "lint", "mypy", "pytype", "contract_tests"
 
 
 @nox_poetry.session
-def tests(session: Session) -> None:
-    """Run the test suite."""
-    args = session.posargs or ["--cov"]
-    session.install(
-        ".",
-        "coverage[toml]",
-        "pytest",
-        "pytest-cov",
-    )
-    session.run(
-        "pytest",
-        "-m unit",
-        "-rA",
-        *args,
-        env={"ALTINN_URI": "altinn-uri"},
-    )
-    session.run("pytest", "-m unit", "-rA", *args)
-
-
-@nox_poetry.session
 def contract_tests(session: Session) -> None:
     """Run the contract_test suite."""
     args = session.posargs

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,3 @@
 [pytest]
 markers =
-    unit: marks tests as unit ("fast")
-    integration: marks tests as integration
     contract: marks tests as contract ("slow")


### PR DESCRIPTION
closes #5 

(unit test er ikkje i bruk i tjenesten, så denne PR fjerner referanser til slike tester i config og noxfile.py)